### PR TITLE
Create 3_glibc-2.13_locale_t_compat.patch

### DIFF
--- a/patches/3_glibc-2.13_locale_t_compat.patch
+++ b/patches/3_glibc-2.13_locale_t_compat.patch
@@ -1,0 +1,5 @@
+diff -Naur glibc-2.13/locale/bits/types/locale_t.h glibc-2.13_locale_t_compat/locale/bits/types/locale_t.h
+--- glibc-2.13/locale/bits/types/locale_t.h	1970-01-01 03:00:00.000000000 +0300
++++ glibc-2.13_locale_t_compat/locale/bits/types/locale_t.h	2022-01-17 10:38:19.360286000 +0300
+@@ -0,0 +1 @@
++#include <xlocale.h>


### PR DESCRIPTION
A patch fixing the issue with locale_t while compiling with the newest gcc