### PR TITLE
CI: initial commit

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # container: ghcr.io/${{ github.repository_owner }}/mipsr5900el-gentoo-linux-gnu:main
-    container: ghcr.io/${{ github.repository_owner }}/mipsr5900el-gentoo-linux-gnu:main
+    container: ghcr.io/frno7/mipsr5900el-gentoo-linux-gnu:main
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -30,14 +30,14 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: initramfs
-          path: initramfs
+          path: ../initramfs
 
       - name: Upload kernel as artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
         with:
           name: "PS2Linux5.4-${{ github.sha }}.ELF"
-          path: linux/PS2Linux5.4-${{ github.sha }}.ELF
+          path: PS2Linux5.4-${{ github.sha }}.ELF
 
       - name: Upload kernel as pre-release
         if: github.ref == 'refs/heads/ps2-main'
@@ -47,4 +47,4 @@ jobs:
           prerelease: true
           automatic_release_tag: "latest"
           title: PS2Linux5.4-${{ github.sha }}.ELF
-          files: linux/PS2Linux5.4-${{ github.sha }}.ELF
+          files: PS2Linux5.4-${{ github.sha }}.ELF

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -17,7 +17,7 @@ jobs:
           INSTALL_MOD_PATH: ../initramfs/ps2/
           INSTALL_MOD_STRIP: 1
         run: |
-          mv -f ../srv/initramfs ../
+          mv -f /srv/initramfs ../
           make -j $(getconf _NPROCESSORS_ONLN) ps2_defconfig
           make -j $(getconf _NPROCESSORS_ONLN) oldconfig
           make -j $(getconf _NPROCESSORS_ONLN) vmlinux

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # container: ghcr.io/${{ github.repository_owner }}/mipsr5900el-gentoo-linux-gnu:main
-    container: ghcr.io/AKuHAK/mipsr5900el-gentoo-linux-gnu:main
+    container: ghcr.io/frno7/mipsr5900el-gentoo-linux-gnu:main
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -26,11 +26,11 @@ jobs:
           make -j $(getconf _NPROCESSORS_ONLN) vmlinuz
           cp vmlinuz PS2Linux5.4-${{ github.sha }}.ELF
 
-      - name: Upload initramfs as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: initramfs
-          path: ../initramfs
+   
+
+
+
+
 
       - name: Upload kernel as artifact
         if: ${{ success() }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -17,7 +17,7 @@ jobs:
           INSTALL_MOD_PATH: ../initramfs/ps2/
           INSTALL_MOD_STRIP: 1
         run: |
-          mv -f ../srv/iniramfs ../
+          mv -f ../srv/initramfs ../
           make -j $(getconf _NPROCESSORS_ONLN) ps2_defconfig
           make -j $(getconf _NPROCESSORS_ONLN) oldconfig
           make -j $(getconf _NPROCESSORS_ONLN) vmlinux

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -23,13 +23,13 @@ jobs:
           make -j $(getconf _NPROCESSORS_ONLN) modules
           make -j $(getconf _NPROCESSORS_ONLN) modules_install
           make -j $(getconf _NPROCESSORS_ONLN) vmlinuz
-          cp vmlinuz PS2Linux5.4-${{ github.sha }}.ELF
+          cp vmlinuz PS2Linux-${{ github.ref_name }}-${{ github.sha }}.ELF
 
       - name: Upload kernel as artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
         with:
-          name: "PS2Linux5.4-${{ github.sha }}.ELF"
+          name: "PS2Linux-${{ github.ref_name }}-${{ github.sha }}.ELF"
           path: PS2Linux-${{ github.ref_name }}-${{ github.sha }}.ELF
 
       - name: Upload initramfs as artifact
@@ -48,5 +48,5 @@ jobs:
           automatic_release_tag: "latest"
           title: Development build
           files: |
-            PS2Linux5.4-${{ github.sha }}.ELF
+            PS2Linux-${{ github.ref_name }}-${{ github.sha }}.ELF
             usr/initramfs_data.cpio*

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -17,7 +17,7 @@ jobs:
           INSTALL_MOD_PATH: ../initramfs/ps2/
           INSTALL_MOD_STRIP: 1
         run: |
-          mv -f ../svr/iniramfs ../
+          mv -f ../srv/iniramfs ../
           make -j $(getconf _NPROCESSORS_ONLN) ps2_defconfig
           make -j $(getconf _NPROCESSORS_ONLN) oldconfig
           make -j $(getconf _NPROCESSORS_ONLN) vmlinux

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -17,7 +17,7 @@ jobs:
           INSTALL_MOD_PATH: ../initramfs/ps2/
           INSTALL_MOD_STRIP: 1
         run: |
-          mv -rf ../svr/iniramfs ../
+          mv -f ../svr/iniramfs ../
           make -j $(getconf _NPROCESSORS_ONLN) ps2_defconfig
           make -j $(getconf _NPROCESSORS_ONLN) oldconfig
           make -j $(getconf _NPROCESSORS_ONLN) vmlinux

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -7,8 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # container: ghcr.io/${{ github.repository_owner }}/mipsr5900el-gentoo-linux-gnu:main
-    container: ghcr.io/frno7/mipsr5900el-gentoo-linux-gnu:main
+    container: ghcr.io/${{ github.repository_owner }}/mipsr5900el-gentoo-linux-gnu:main
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -1,0 +1,50 @@
+name: CI-compile
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # container: ghcr.io/${{ github.repository_owner }}/mipsr5900el-gentoo-linux-gnu:main
+    container: ghcr.io/AKuHAK/mipsr5900el-gentoo-linux-gnu:main
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Compile project
+        env:
+          INSTALL_MOD_PATH: ../initramfs/ps2/
+          INSTALL_MOD_STRIP: 1
+        run: |
+          mv -rf ../svr/iniramfs ../
+          make -j $(getconf _NPROCESSORS_ONLN) ps2_defconfig
+          make -j $(getconf _NPROCESSORS_ONLN) oldconfig
+          make -j $(getconf _NPROCESSORS_ONLN) vmlinux
+          make -j $(getconf _NPROCESSORS_ONLN) modules
+          make -j $(getconf _NPROCESSORS_ONLN) modules_install
+          make -j $(getconf _NPROCESSORS_ONLN) vmlinuz
+          cp vmlinuz PS2Linux5.4-${{ github.sha }}.ELF
+
+      - name: Upload initramfs as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: initramfs
+          path: initramfs
+
+      - name: Upload kernel as artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: "PS2Linux5.4-${{ github.sha }}.ELF"
+          path: linux/PS2Linux5.4-${{ github.sha }}.ELF
+
+      - name: Upload kernel as pre-release
+        if: github.ref == 'refs/heads/ps2-main'
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
+          automatic_release_tag: "latest"
+          title: PS2Linux5.4-${{ github.sha }}.ELF
+          files: linux/PS2Linux5.4-${{ github.sha }}.ELF

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: "PS2Linux5.4-${{ github.sha }}.ELF"
-          path: PS2Linux5.4-${{ github.sha }}.ELF
+          path: PS2Linux-${{ github.ref_name }}-${{ github.sha }}.ELF
 
       - name: Upload initramfs as artifact
         if: ${{ success() }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/${{ github.repository_owner }}/mipsr5900el-gentoo-linux-gnu:main
+    container: ghcr.io/frno7/mipsr5900el-gentoo-linux-gnu:main
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # container: ghcr.io/${{ github.repository_owner }}/mipsr5900el-gentoo-linux-gnu:main
-    container: ghcr.io/frno7/mipsr5900el-gentoo-linux-gnu:main
+    container: ghcr.io/${{ github.repository_owner }}/mipsr5900el-gentoo-linux-gnu:main
     steps:
       - uses: actions/checkout@v3
 
@@ -26,18 +26,19 @@ jobs:
           make -j $(getconf _NPROCESSORS_ONLN) vmlinuz
           cp vmlinuz PS2Linux5.4-${{ github.sha }}.ELF
 
-   
-
-
-
-
-
       - name: Upload kernel as artifact
         if: ${{ success() }}
         uses: actions/upload-artifact@v3
         with:
           name: "PS2Linux5.4-${{ github.sha }}.ELF"
           path: PS2Linux5.4-${{ github.sha }}.ELF
+
+      - name: Upload initramfs as artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Initramfs
+          path: usr/initramfs_data.cpio*
 
       - name: Upload kernel as pre-release
         if: github.ref == 'refs/heads/ps2-main'
@@ -46,5 +47,7 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: true
           automatic_release_tag: "latest"
-          title: PS2Linux5.4-${{ github.sha }}.ELF
-          files: PS2Linux5.4-${{ github.sha }}.ELF
+          title: Development build
+          files: |
+            PS2Linux5.4-${{ github.sha }}.ELF
+            usr/initramfs_data.cpio*

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ modules.order
 !.gitattributes
 !.gitignore
 !.mailmap
+!.github
 
 #
 # Generated include files


### PR DESCRIPTION
Added precompiled binary generation based on a special Docker image.

@frno7 this step needs some preparations for it to work:

- [x] Go to URL https://github.com/frno7/linux/actions and enable Github Actions
- [x] You need to create https://github.com/frno7/mipsr5900el-linux-gnu so I can provide a PR for a working Gentoo-based Docker image. Currently, it has inside R5900 cross-compiler, busybox, qemu, minimal initramfs, iopmod precompiled and placed inside initramfs.
- [x] Before building the docker image it will be useful to resolve [this issue](https://github.com/frno7/gentoo.overlay/issues/1). So I can remove references to my repo.
- [x] After the Docker image is built inside https://github.com/frno7/mipsr5900el-linux-gnu (it takes more than 1 hour) Then go to https://github.com/users/frno7/packages/container/mipsr5900el-linux-gnu/settings and change the visibility to Public.
- [ ] Merge this PR. Wiki can be updated with links to neither [last successful build](https://github.com/frno7/linux/releases/tag/latest) nor [action list](https://github.com/AKuHAK/linux/actions?query=is%3Asuccess) if someone wants to test some older build by clicking on any action and grabbing precompiled elf from artifacts section (note: artifacts sections is accessible only for logged into GitHub users).
- [x] Prepare CI for each child repository like iopmod or linux.